### PR TITLE
Try to get contextive definitions if not defined in the config

### DIFF
--- a/src/language-server/Contextive.LanguageServer.Tests/InitializationTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/InitializationTests.fs
@@ -68,17 +68,16 @@ let initializationTests =
                   @>
           }
 
-          testAsync "Server fails to load contextive file with error when no configuration supplied" {
+          testAsync "Server loads contextive file from default location when no configuration supplied" {
               let config =
                   [ Workspace.optionsBuilder ""
                     ConfigurationSection.optionsBuilder "dummySection" (fun () -> Map []) ]
 
-              let! (client, reply) = TestClientWithCustomInitWait(config, Some "contextive") |> initAndWaitForReply
+              let defaultPath = ".contextive/definitions.yml"
 
-              test
-                  <@
-                      (defaultArg reply "") = "Error loading definitions: No path defined - please check \"contextive.path\" setting."
-                  @>
+              let! (client, reply) = TestClient(config) |> initAndWaitForReply
+
+              test <@ (defaultArg reply "").Contains(defaultPath) @>
           }
 
           ]

--- a/src/language-server/Contextive.LanguageServer/Server.fs
+++ b/src/language-server/Contextive.LanguageServer/Server.fs
@@ -12,6 +12,9 @@ open Serilog
 open System.IO
 open System.Reflection
 
+[<Literal>]
+let defaultContextiveDefinitionsPath = ".contextive/definitions.yml"
+
 let configSection = "contextive"
 let pathKey = "path"
 let assembly = Assembly.GetExecutingAssembly()
@@ -33,10 +36,12 @@ let private getConfig (s: ILanguageServer) section key =
         let configValue = config.GetSection(section).Item(key)
 
         let value =
-            match configValue with
-            | ""
-            | null -> None
-            | _ -> Some configValue
+            if System.String.IsNullOrEmpty configValue then
+                match key with
+                | key when key = pathKey -> Some defaultContextiveDefinitionsPath
+                | _ -> None
+            else
+                Some configValue
 
         Log.Logger.Information $"Got {key} {value}"
         return value


### PR DESCRIPTION
Hello @chrissimon-au! Firstly thanks for the great concept (and the language-server that comes with it!).

### Background

This concept sounds really useful, as the knowledge bank can be stored in one file and work across different file formats. I can see multiple use cases for this. As an avid user of neovim, I was eager to try this language server with my setup. Unfortunately, probably due to my lack of knowledge in the realm of LSP (Language Server Protocol), I couldn't get it to work right out of the box. I kept encountering the `missing contextive.path` error. As a result, I decided to make the user experience a bit easier, meaning less necessary configuration, so that "it just works".

### Neovim setup

I'm using the neovim builtin lsp with lspconfig, and this is my working setup for contextive language-server:

```lua
local ok, configs = pcall(require, "lspconfig.configs")
if not ok then
  return
end

configs.contextive = {
  default_config = {
    filetypes = { "*" },
    on_attach = on_attach,
    root_dir = lspconfig.util.root_pattern('.contextive'),
    cmd = { "~/lsp/Contextive.LanguageServer" }, -- This is a temporary path for now
  },
}

lspconfig.contextive.setup {}
```

The above language-server configuration is attached to all buffers / all filetypes.

### Implementation

This is an enhancement to the language server that enables it to automatically use the contextive definitions path if it's found in the workspace, and if the `contextive.path` configuration is not defined.

Add a new function called `getContextiveDefinitionsPath`, which returns the contextive definitions path if it exists in the workspace.

By default, the language-server uses the `contextive.path` defined by the caller.

And this is how it works and looks like in the sample repository:
<img width="923" alt="contextive-sample-nvim" src="https://github.com/dev-cycles/contextive/assets/15418377/1e73c2e4-2c95-43a4-8956-f005feb3c64a">