### PR TITLE
Language server release

### DIFF
--- a/.github/workflows/contextive-vscode-publish.yml
+++ b/.github/workflows/contextive-vscode-publish.yml
@@ -69,10 +69,16 @@ jobs:
         id: get-version
         shell: bash
         working-directory: ./src/vscode/contextive
-      - name: Zip Language Server
+      - name: Zip Language Server (Ubuntu)
         run: |
           zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}-${{ steps.get-version.outputs.VERSION}}.zip * 
         working-directory: ./src/language-server/Contextive.LanguageServer/publish
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+      - name: Zip Language Server (Others)
+        run: |
+          7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}-${{ steps.get-version.outputs.VERSION}}.zip * 
+        working-directory: ./src/language-server/Contextive.LanguageServer/publish
+        if: ${{ ! contains(matrix.os, 'ubuntu') }}
       - name: Upload Language Server to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Zip Language Server (Ubuntu)
         run: |
           zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer/bin/debug/net-6.0
+        working-directory: ./src/language-server/Contextive.LanguageServer/bin/Debug/net-6.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Zip Language Server (Other)
         run: |
           7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer/bin/debug/net-6.0
+        working-directory: ./src/language-server/Contextive.LanguageServer/bin/Debug/net-6.0
         if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'windows') }} 
 
       - name: Upload Language Server Test Results

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Zip Language Server (Ubuntu)
         run: |
           zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net-6.0
+        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net6.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Zip Language Server (Other)
         run: |
           7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net-6.0
+        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net6.0
         if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'windows') }} 
 
       - name: Upload Language Server Test Results

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Zip Language Server (Ubuntu)
         run: |
           zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer/publish
+        working-directory: ./src/language-server/Contextive.LanguageServer/bin/debug/net-6.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Zip Language Server (Other)
         run: |
           7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer/publish
+        working-directory: ./src/language-server/Contextive.LanguageServer/bin/debug/net-6.0
         if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'windows') }} 
 
       - name: Upload Language Server Test Results

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -21,6 +21,16 @@ jobs:
           - dotnet_runtime: linux-x64
             vsce_platform: linux-x64
             os: ubuntu-latest
+          # temporary for testing cross-platform zipping
+          - dotnet_runtime: linux-arm64
+            vsce_platform: linux-arm64
+            os: ubuntu-latest
+          - dotnet_runtime: osx-x64
+            vsce_platform: darwin-x64
+            os: macos-latest
+          - dotnet_runtime: osx-arm64
+            vsce_platform: darwin-arm64
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -51,6 +61,20 @@ jobs:
       - name: Build and Test Language Server
         run: |
           dotnet test ./src/language-server/Contextive.LanguageServer.Tests/Contextive.LanguageServer.Tests.fsproj --logger "trx;LogFileName=TestResults.LanguageServer-${{ env.dotnet-version }}-${{ runner.os }}.xml" -- Expecto.fail-on-focused-tests=true
+      
+      # temporary for testing cross-platform zipping
+      - name: Zip Language Server (Ubuntu)
+        run: |
+          zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
+        working-directory: ./src/language-server/Contextive.LanguageServer/publish
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+
+      - name: Zip Language Server (Other)
+        run: |
+          7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
+        working-directory: ./src/language-server/Contextive.LanguageServer/publish
+        if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'windows') }} 
+
       - name: Upload Language Server Test Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -51,20 +51,6 @@ jobs:
       - name: Build and Test Language Server
         run: |
           dotnet test ./src/language-server/Contextive.LanguageServer.Tests/Contextive.LanguageServer.Tests.fsproj --logger "trx;LogFileName=TestResults.LanguageServer-${{ env.dotnet-version }}-${{ runner.os }}.xml" -- Expecto.fail-on-focused-tests=true
-      
-      # temporary for testing cross-platform zipping
-      - name: Zip Language Server (Ubuntu)
-        run: |
-          zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net6.0
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-
-      - name: Zip Language Server (Other)
-        run: |
-          7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net6.0
-        if: ${{ ! contains(matrix.os, 'ubuntu') }}
-
       - name: Upload Language Server Test Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -21,16 +21,6 @@ jobs:
           - dotnet_runtime: linux-x64
             vsce_platform: linux-x64
             os: ubuntu-latest
-          # temporary for testing cross-platform zipping
-          - dotnet_runtime: linux-arm64
-            vsce_platform: linux-arm64
-            os: ubuntu-latest
-          - dotnet_runtime: osx-x64
-            vsce_platform: darwin-x64
-            os: macos-latest
-          - dotnet_runtime: osx-arm64
-            vsce_platform: darwin-arm64
-            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -73,7 +63,7 @@ jobs:
         run: |
           7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
         working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net6.0
-        if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'windows') }} 
+        if: ${{ ! contains(matrix.os, 'ubuntu') }}
 
       - name: Upload Language Server Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/contextive-vscode.yml
+++ b/.github/workflows/contextive-vscode.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Zip Language Server (Ubuntu)
         run: |
           zip ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer/bin/Debug/net-6.0
+        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net-6.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Zip Language Server (Other)
         run: |
           7z a ../Contextive.LanguageServer-${{ matrix.dotnet_runtime }}.zip * 
-        working-directory: ./src/language-server/Contextive.LanguageServer/bin/Debug/net-6.0
+        working-directory: ./src/language-server/Contextive.LanguageServer.Tests/bin/Debug/net-6.0
         if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'windows') }} 
 
       - name: Upload Language Server Test Results


### PR DESCRIPTION
Alter language server zip step to be cross-platform by using `zip` on ubuntu and `7zip` on windows and macos.