### PR TITLE
Use a config variable to store configuration changes

### DIFF
--- a/src/language-server/Contextive.LanguageServer/Configuration.fs
+++ b/src/language-server/Contextive.LanguageServer/Configuration.fs
@@ -1,6 +1,7 @@
 module Contextive.LanguageServer.Configuration
 
 open System.Threading.Tasks
+open OmniSharp.Extensions.LanguageServer.Protocol.Models
 
 let resolvedPathGetter configGetter pathResolver () =
     async {
@@ -8,6 +9,10 @@ let resolvedPathGetter configGetter pathResolver () =
         return pathResolver path
     }
 
-let handler (definitionsLoader: Definitions.Reloader) _ =
+type Config = { mutable Path: string option }
+
+let handler (config: Config) (definitionsLoader: Definitions.Reloader) (configParams: DidChangeConfigurationParams) =
+    let path = configParams.Settings.Item("contextive").Item("path")
+    config.Path <- Some(path.ToString())
     definitionsLoader ()
     Task.CompletedTask

--- a/src/language-server/Contextive.LanguageServer/Definitions.fs
+++ b/src/language-server/Contextive.LanguageServer/Definitions.fs
@@ -136,9 +136,7 @@ module private Handle =
         let matchOpenFileUri = matchGlobs findMsg.OpenFileUri
 
         let foundContexts =
-            state.Definitions.Contexts
-            |> Seq.filter matchOpenFileUri
-            |> findMsg.Filter
+            state.Definitions.Contexts |> Seq.filter matchOpenFileUri |> findMsg.Filter
 
         findMsg.ReplyChannel.Reply foundContexts
         state


### PR DESCRIPTION
### Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
> Where is commit message guidelines?
- [ ] Tests for the changes have been added (for bug fixes / features)
> Adding resilience so I don't think new test cases need to be formulated.
- [ ] Docs have been added / updated (for bug fixes / features)

### Context
When using for example the neovim language server client, the contextive language server does not acquire the proper settings sent by the client in the `OnStarted` handler. However, the settings are passed correctly using the `OnDidChangeConfiguration` handler.

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This change introduces a scoped variable in the server start function to hold a mutable field for the Contextive path configuration. The configuration variable is initialized with the default path for Contextive definitions introduced in commit 23f9049. If the language configuration does not have a config value, it will use the value from the configuration variable instead. This works the same way as it did previously, but the source is now a parameter of the function.

### What is the current behavior? (You can also link to an open issue here)
Currently the configuration initialization does not work correctly with nvim (v0.9.2) language client server. I've spent multiple hours trying to understand the cause for this, but alas I'm empty handed here. There must be something that is not right, maybe it could be an OmniSharp issue too.

### Other information:
This work is related to https://github.com/dev-cycles/contextive/issues/33