### PR TITLE
fix(language-server): support LSP clients that only support `workspace/configuration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following list of features is a draft proposal of the vision at the start of
   * [ ] Eclipse
   * [ ] NetBeans
   * [ ] JetBrains
-  * [ ] vim
+  * [x] neovim
   * [ ] emacs
 * [ ] Code-editing Features
   * [x] Show the term definitions & usage examples when hovering over the word in the editor 
@@ -128,6 +128,7 @@ lspconfig_configs.contextive = {
   default_config = {
     cmd = { "Contextive.LanguageServer" },
     root_dir = lspconfig.util.root_pattern('.contextive', '.git'),
+    --settings={contextive={path="./path/to/definitions.yml"} -- uncomment this line to nominate a custom definitions.yml file location
   },
 }
 

--- a/src/language-server/Contextive.LanguageServer.Tests/CompletionTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/CompletionTests.fs
@@ -30,7 +30,7 @@ let completionTests =
                   $"Given {fileName} contextive, in document {text} at position {position} respond with expected completion list " {
                   let config =
                       [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                        ConfigurationSection.contextivePathOptionsBuilder $"{fileName}.yml" ]
+                        ConfigurationSection.contextivePathBuilder $"{fileName}.yml" ]
 
                   use! client = TestClient(config) |> init
 

--- a/src/language-server/Contextive.LanguageServer.Tests/ConfigurationTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/ConfigurationTests.fs
@@ -13,7 +13,7 @@ let definitionsTests =
         [ testAsync "Can receive configuration value" {
               let config =
                   [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                    ConfigurationSection.contextivePathOptionsBuilder "one.yml" ]
+                    ConfigurationSection.contextivePathBuilder "one.yml" ]
 
               use! client = TestClient(config) |> init
 
@@ -29,16 +29,31 @@ let definitionsTests =
 
               let config =
                   [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                    ConfigurationSection.contextivePathLoaderOptionsBuilder pathLoader ]
+                    ConfigurationSection.contextivePathLoaderBuilder pathLoader ]
 
               use! client = TestClient(config) |> init
 
               path <- "two.yml"
-              ConfigurationSection.didChange client path
+              ConfigurationSection.didChangePath client path
 
               let! labels = Completion.getCompletionLabels client
 
               test <@ (labels, Fixtures.Two.expectedCompletionLabels) ||> Seq.compareWith compare = 0 @>
+
+          }
+
+          testAsync "Can handle client that doesn't support didChangeConfiguration" {
+              let mutable path = "one.yml"
+
+              let config =
+                  [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
+                    ConfigurationSection.contextivePathBuilder path ]
+
+              use! client = TestClient(config) |> init
+
+              let! labels = Completion.getCompletionLabels client
+
+              test <@ (labels, Fixtures.One.expectedCompletionLabels) ||> Seq.compareWith compare = 0 @>
 
           }
 

--- a/src/language-server/Contextive.LanguageServer.Tests/DefinitionsTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/DefinitionsTests.fs
@@ -163,7 +163,7 @@ let definitionsTests =
 
                   let config =
                       [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                        ConfigurationSection.contextivePathLoaderOptionsBuilder pathLoader ]
+                        ConfigurationSection.contextivePathLoaderBuilder pathLoader ]
 
                   use! client = TestClient(config) |> init
 
@@ -171,13 +171,13 @@ let definitionsTests =
                   test <@ (termsWhenValidAtStart, Fixtures.One.expectedCompletionLabels) ||> compareList = 0 @>
 
                   path <- $"{fileName}.yml"
-                  ConfigurationSection.didChange client path
+                  ConfigurationSection.didChangePath client path
 
                   let! termsWhenInvalid = Completion.getCompletionLabels client
                   test <@ Seq.length termsWhenInvalid = 0 @>
 
                   path <- validPath
-                  ConfigurationSection.didChange client path
+                  ConfigurationSection.didChangePath client path
 
                   let! termsWhenValidAtEnd = Completion.getCompletionLabels client
                   test <@ (termsWhenValidAtEnd, Fixtures.One.expectedCompletionLabels) ||> compareList = 0 @>

--- a/src/language-server/Contextive.LanguageServer.Tests/HoverTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/HoverTests.fs
@@ -37,7 +37,7 @@ let hoverTests =
                   $"Given definitions file '{fileName}' and file contents '{multiLineToSingleLine text}', server responds to hover request at Position {position} with '{expectedTerm}'" {
                   let config =
                       [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                        ConfigurationSection.contextivePathOptionsBuilder $"{fileName}.yml" ]
+                        ConfigurationSection.contextivePathBuilder $"{fileName}.yml" ]
 
                   use! client = TestClient(config) |> init
 
@@ -89,7 +89,7 @@ let hoverTests =
 
                   let config =
                       [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                        ConfigurationSection.contextivePathOptionsBuilder $"{fileName}.yml" ]
+                        ConfigurationSection.contextivePathBuilder $"{fileName}.yml" ]
 
                   use! client = TestClient(config) |> init
 
@@ -129,7 +129,7 @@ let hoverTests =
 
                   let config =
                       [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                        ConfigurationSection.contextivePathOptionsBuilder $"{fileName}.yml" ]
+                        ConfigurationSection.contextivePathBuilder $"{fileName}.yml" ]
 
                   use! client = TestClient(config) |> init
 

--- a/src/language-server/Contextive.LanguageServer.Tests/InitializationTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/InitializationTests.fs
@@ -28,12 +28,11 @@ let initializationTests =
 
               let config =
                   [ Workspace.optionsBuilder ""
-                    ConfigurationSection.contextivePathOptionsBuilder pathValue ]
+                    ConfigurationSection.contextivePathBuilder pathValue ]
 
               let! (client, reply) = TestClient(config) |> initAndWaitForReply
 
               test <@ client.ClientSettings.Capabilities.Workspace.Configuration.IsSupported @>
-              test <@ client.ClientSettings.Capabilities.Workspace.DidChangeConfiguration.IsSupported @>
 
               test <@ (defaultArg reply "").Contains(pathValue) @>
           }
@@ -41,25 +40,22 @@ let initializationTests =
           testAsync "Server loads contextive file from absolute location without workspace" {
               let pathValue = Guid.NewGuid().ToString()
 
-              let config =
-                  [ ConfigurationSection.contextivePathOptionsBuilder $"/tmp/{pathValue}" ]
+              let config = [ ConfigurationSection.contextivePathBuilder $"/tmp/{pathValue}" ]
 
               let! (client, reply) = TestClient(config) |> initAndWaitForReply
 
               test <@ client.ClientSettings.Capabilities.Workspace.Configuration.IsSupported @>
-              test <@ client.ClientSettings.Capabilities.Workspace.DidChangeConfiguration.IsSupported @>
 
               test <@ (defaultArg reply "").Contains(pathValue) @>
           }
 
           testAsync "Server does NOT load contextive file from relative location without workspace" {
               let pathValue = Guid.NewGuid().ToString()
-              let config = [ ConfigurationSection.contextivePathOptionsBuilder pathValue ]
+              let config = [ ConfigurationSection.contextivePathBuilder pathValue ]
 
               let! (client, reply) = TestClientWithCustomInitWait(config, Some pathValue) |> initAndWaitForReply
 
               test <@ client.ClientSettings.Capabilities.Workspace.Configuration.IsSupported @>
-              test <@ client.ClientSettings.Capabilities.Workspace.DidChangeConfiguration.IsSupported @>
 
               test
                   <@
@@ -71,7 +67,7 @@ let initializationTests =
           testAsync "Server loads contextive file from default location when no configuration supplied" {
               let config =
                   [ Workspace.optionsBuilder ""
-                    ConfigurationSection.optionsBuilder "dummySection" (fun () -> Map []) ]
+                    ConfigurationSection.configurationHandlerBuilder "dummySection" (fun () -> Map []) ]
 
               let defaultPath = ".contextive/definitions.yml"
 

--- a/src/language-server/Contextive.LanguageServer.Tests/SurveyTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/SurveyTests.fs
@@ -48,7 +48,7 @@ let initializationTests =
               let config =
                   [ showMessageRequestHandlerBuilder <| handler messageAwaiter null
                     Workspace.optionsBuilder ""
-                    ConfigurationSection.contextivePathOptionsBuilder pathValue ]
+                    ConfigurationSection.contextivePathBuilder pathValue ]
 
               let! (client, reply) = TestClient(config) |> initAndWaitForReply
 
@@ -75,7 +75,7 @@ let initializationTests =
               let config =
                   [ showMessageRequestHandlerBuilder <| handler messageAwaiter null
                     Workspace.optionsBuilder ""
-                    ConfigurationSection.contextivePathOptionsBuilder pathValue ]
+                    ConfigurationSection.contextivePathBuilder pathValue ]
 
               let! (client, reply) = TestClient(config) |> initAndWaitForReply
 
@@ -102,7 +102,7 @@ let initializationTests =
                   [ showMessageRequestHandlerBuilder <| handler messageAwaiter response
                     showDocumentRequestHandlerBuilder <| handler showDocAwaiter showDocResponse
                     Workspace.optionsBuilder ""
-                    ConfigurationSection.contextivePathOptionsBuilder pathValue ]
+                    ConfigurationSection.contextivePathBuilder pathValue ]
 
               let! (client, reply) = TestClient(config) |> initAndWaitForReply
 

--- a/src/language-server/Contextive.LanguageServer.Tests/TextDocumentTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/TextDocumentTests.fs
@@ -52,7 +52,7 @@ let textDocumentTests =
           testAsync "Server supports full sync" {
               let config =
                   [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                    ConfigurationSection.contextivePathOptionsBuilder $"one.yml" ]
+                    ConfigurationSection.contextivePathBuilder $"one.yml" ]
 
               use! client = TestClient(config) |> init
               test <@ client.ServerSettings.Capabilities.TextDocumentSync.Options.Change = TextDocumentSyncKind.Full @>

--- a/src/language-server/Contextive.LanguageServer.Tests/WatchedFilesTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/WatchedFilesTests.fs
@@ -36,7 +36,7 @@ let watchedFileTests =
 
               let config =
                   [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                    ConfigurationSection.contextivePathOptionsBuilder $"one.yml"
+                    ConfigurationSection.contextivePathBuilder $"one.yml"
                     WatchedFiles.optionsBuilder registrationAwaiter ]
 
               let! client = TestClient(config) |> init
@@ -62,7 +62,7 @@ let watchedFileTests =
 
                   let config =
                       [ Workspace.optionsBuilder <| Path.Combine("fixtures", "completion_tests")
-                        ConfigurationSection.contextivePathLoaderOptionsBuilder pathLoader
+                        ConfigurationSection.contextivePathLoaderBuilder pathLoader
                         WatchedFiles.optionsBuilder registrationAwaiter ]
 
                   let! client = TestClient(config) |> init
@@ -72,7 +72,7 @@ let watchedFileTests =
                   ConditionAwaiter.clear registrationAwaiter 500
 
                   definitionsFile <- newDefinitionsFile
-                  ConfigurationSection.didChange client definitionsFile
+                  ConfigurationSection.didChangePath client definitionsFile
 
                   let! secondRegistrationMsg =
                       ConditionAwaiter.waitFor
@@ -113,7 +113,7 @@ let watchedFileTests =
 
               let config =
                   [ Workspace.optionsBuilder relativePath
-                    ConfigurationSection.contextivePathOptionsBuilder definitionsFile ]
+                    ConfigurationSection.contextivePathBuilder definitionsFile ]
 
               let! client = TestClient(config) |> init
 
@@ -153,7 +153,7 @@ let watchedFileTests =
 
               let config =
                   [ Workspace.optionsBuilder relativePath
-                    ConfigurationSection.contextivePathOptionsBuilder definitionsFile ]
+                    ConfigurationSection.contextivePathBuilder definitionsFile ]
 
               let! client = TestClient(config) |> init
 

--- a/src/language-server/Contextive.LanguageServer/Server.fs
+++ b/src/language-server/Contextive.LanguageServer/Server.fs
@@ -30,7 +30,10 @@ let private getConfig (s: ILanguageServer) section key =
         Log.Logger.Information $"Getting {section} {key} config..."
 
         let! config =
-            s.Configuration.GetConfiguration(ConfigurationItem(Section = configSection))
+            // We need to use `GetScopedConfiguration` because of https://github.com/OmniSharp/csharp-language-server-protocol/issues/1101
+            // We can revert to `GetConfiguration` when that bug is fixed.
+            s.Configuration.GetScopedConfiguration("file:///", System.Threading.CancellationToken.None)
+            //s.Configuration.GetConfiguration(ConfigurationItem(Section = configSection))
             |> Async.AwaitTask
 
         let configValue = config.GetSection(section).Item(key)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

To compensate for https://github.com/OmniSharp/csharp-language-server-protocol/issues/1101, switch to using _scoped_ configuration method which doesn't (incorrectly) rely on the `didChangeConfiguration` capability from the client.

Added a test to simulate the scenario we see with `neovim` where it offers the `workspace.configuration` capability but not the `workspace.didChangeConfiguration` capability.  (This test failed before the change, and went green after the change).

Refactored the test helper `ConfigurationSection` to simplify that scenario, and to more generally rely less on `didChangeConfiguration` capability for tests that only use static setting values.

* **What is the current behavior?** (You can also link to an open issue here)

Due to the aforementioned OmniSharp bug, Contextive was not able to obtain configuration settings from `neovim` client.  A workaround was explored by @erikjuhani on #55, but now that we know the root cause is a library bug, this is the minimally disruptive solution.

* **What is the new behavior (if this is a feature change)?**

By using the `GetScopedConfiguration`, we bypass the `didChangeConfiguration` capability check.  See https://github.com/OmniSharp/csharp-language-server-protocol/issues/1101 for details.  We should revert this change (but not the tests) after that issue is resolved.

Also, now that this works, the neovim README.md section has been updated to illustrate how to nominate a custom definitions file location.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

See also #54 for other in-filght considerations around the configuration story.