### PR TITLE
docs: update neovim lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ How to configure Neovim with lua modules: https://neovim.io/doc/user/lua-guide.h
 
 Contextive Language Server is also provided with [Mason](https://github.com/williamboman/mason.nvim).
 
+To install Contextive with Mason, execute the Mason install command in Neovim.
+
+```
+:MasonInstall contextive
+```
+
+The following configuration requires the `neovim/nvim-lspconfig` plugin, which can be installed and set up by following this [install guide](https://github.com/neovim/nvim-lspconfig#install).
+
 Use lspconfig to setup and initialize the Contextive Language Server configuration. The following lua snippet needs to be included in the `init.lua` file either directly or from another lua module like `lspconfigs.lua`.
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -117,22 +117,26 @@ The command should return the absolute path to the binary if it's found in the s
 
 How to configure Neovim with lua modules: https://neovim.io/doc/user/lua-guide.html#lua-guide-config
 
-Use lspconfig to create a custom contextive language server configuration and initialize the language server by calling the setup function. The following lua snippet needs to be included in the `init.lua` file either directly or from another lua module like `lspconfigs.lua`.
+Contextive Language Server is also provided with [Mason](https://github.com/williamboman/mason.nvim).
+
+Use lspconfig to setup and initialize the Contextive Language Server configuration. The following lua snippet needs to be included in the `init.lua` file either directly or from another lua module like `lspconfigs.lua`.
 
 ```lua
 local lspconfig = require("lspconfig")
 
-local lspconfig_configs = require("lspconfig.configs")
-
-lspconfig_configs.contextive = {
-  default_config = {
-    cmd = { "Contextive.LanguageServer" },
-    root_dir = lspconfig.util.root_pattern('.contextive', '.git'),
-    --settings={contextive={path="./path/to/definitions.yml"} -- uncomment this line to nominate a custom definitions.yml file location
-  },
-}
-
 lspconfig.contextive.setup {}
+```
+
+To enable a custom path for contextive terms, include these settings in the language server setup configuration.
+
+```lua
+lspconfig.contextive.setup {
+  settings = {
+    contextive = {
+      path = "./path/to/definitions.yml"
+    }
+  }
+}
 ```
 
 ### Others


### PR DESCRIPTION
### Summary

Include a reference to the option of installing the Contextive Language Server from Mason, as Contextive was recently incorporated into the Mason registry.

Prefer the default Contextive lspconfig loaded from nvim-lspconfig.

Provide two examples of setting up the Contextive language server: one using default settings and another for defining a custom path.

### What kind of change does this PR introduce?

Document update to reflect the recent changes done to mason registry and nvim-lspconfig for neovim setup.

### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines (see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)