### PR TITLE
feat: add substring matching for CJK tokens in hover lookup

### DIFF
--- a/src/core/Contextive.Core.Tests/CandidateTermsTests.fs
+++ b/src/core/Contextive.Core.Tests/CandidateTermsTests.fs
@@ -29,6 +29,32 @@ let tokenAndPartsTests =
                           ||> Seq.compareWith compareTokenAndCandidateTerms = 0
                       @>
 
+          testList
+              "CJK Detection Tests"
+              [ testCase "English text is not CJK"
+                <| fun () -> test <@ containsCJK "reverseAuction" = false @>
+
+                testCase "Japanese kanji is CJK"
+                <| fun () -> test <@ containsCJK "注文が届く" = true @>
+
+                testCase "Japanese katakana is CJK"
+                <| fun () -> test <@ containsCJK "カテゴリ" = true @>
+
+                testCase "Chinese text is CJK"
+                <| fun () -> test <@ containsCJK "购物车" = true @>
+
+                testCase "Korean text is CJK"
+                <| fun () -> test <@ containsCJK "사용자" = true @>
+
+                testCase "Mixed English and Japanese is CJK"
+                <| fun () -> test <@ containsCJK "Orderマッピング" = true @>
+
+                testCase "Empty string is not CJK"
+                <| fun () -> test <@ containsCJK "" = false @>
+
+                testCase "Cyrillic is not CJK"
+                <| fun () -> test <@ containsCJK "ОдинДва" = false @> ]
+
           [ ("firstword", seq { ("firstword", seq { "firstword" }) })
             ("camelCase",
              seq {

--- a/src/core/Contextive.Core.Tests/GlossaryFileTests.fs
+++ b/src/core/Contextive.Core.Tests/GlossaryFileTests.fs
@@ -2,6 +2,7 @@ module Contextive.Core.Tests.GlossaryFileTests
 
 open Contextive.Core.File
 open Contextive.Core.GlossaryFile
+open Contextive.Core.Normalization
 open Expecto
 open Swensen.Unquote
 
@@ -460,4 +461,49 @@ contexts:
                     let primaryTerm = glossaryFile.Contexts[0].Index["firstterm"] |> Seq.exactlyOne
                     test <@ glossaryFile.Contexts[0].Index.ContainsKey "aliasoffirstterm" @>
                     let aliasTerm = glossaryFile.Contexts[0].Index["aliasoffirstterm"] |> Seq.exactlyOne
-                    test <@ primaryTerm.Name = aliasTerm.Name @> ] ]
+                    test <@ primaryTerm.Name = aliasTerm.Name @>
+
+                testCase "Japanese alias is indexed"
+                <| fun () ->
+                    let glossaryFile =
+                        unwrap
+                        <| deserialize
+                            "\
+contexts:
+- terms:
+    - name: Order
+      aliases:
+        - 注文
+"
+
+                    test <@ glossaryFile.Contexts[0].Index.ContainsKey "注文" @>
+                    let term = glossaryFile.Contexts[0].Index["注文"] |> Seq.exactlyOne
+                    test <@ term.Name = "Order" @>
+
+                testCase "Chinese term is indexed"
+                <| fun () ->
+                    let glossaryFile =
+                        unwrap
+                        <| deserialize
+                            "\
+contexts:
+- terms:
+    - name: 购物车
+"
+
+                    test <@ glossaryFile.Contexts[0].Index.ContainsKey "购物车" @>
+
+                testCase "Korean term is indexed"
+                <| fun () ->
+                    let glossaryFile =
+                        unwrap
+                        <| deserialize
+                            "\
+contexts:
+- terms:
+    - name: 주문
+"
+                    // Korean Hangul syllables decompose under NFKD normalization (used by simpleNormalize),
+                    // so we must look up the key using the same normalization as the index builder.
+                    let normalizedKey = simpleNormalize "주문"
+                    test <@ glossaryFile.Contexts[0].Index.ContainsKey normalizedKey @> ] ]

--- a/src/core/Contextive.Core/CandidateTerms.fs
+++ b/src/core/Contextive.Core/CandidateTerms.fs
@@ -28,9 +28,18 @@ let private Default: CandidateTerms = Seq.empty<CandidateTerm>
 let private TokenSplitterRegex =
     "([A-Z\\p{Lu}]+(?![a-z\\p{Ll}])|[A-Z\\p{Lu}][a-z\\p{Ll}]+|[0-9]+|[a-z\\p{Ll}]+)"
 
+let containsCJK (token: string) =
+    token |> Seq.exists (fun c ->
+        let cp = int c
+        (cp >= 0x3000 && cp <= 0x9FFF)    // CJK main ranges (kana, CJK unified ideographs, etc.)
+        || (cp >= 0xAC00 && cp <= 0xD7AF) // Hangul syllables
+        || (cp >= 0xF900 && cp <= 0xFAFF) // CJK compatibility ideographs
+    )
+
 let candidateTermsFromToken =
     function
     | None -> Default
+    | Some(token) when containsCJK token -> seq { token }
     | Some(Regex TokenSplitterRegex tokens) -> tokens
     | Some(token) -> seq { token }
 

--- a/src/language-server/Contextive.LanguageServer.Tests/E2e/HoverTests.fs
+++ b/src/language-server/Contextive.LanguageServer.Tests/E2e/HoverTests.fs
@@ -94,6 +94,18 @@ let tests =
           |> List.map testHoverTermFoundWithDefaultGlossary
           |> testList "Term found when hovering in opened docs at Positions"
 
+          [ "注文", Position(0, 0), "注文", "cjk"
+            "注文が届く", Position(0, 0), "注文", "cjk"
+            "購入する", Position(0, 0), "購入", "cjk"
+            "配送についての質問", Position(0, 0), "配送", "cjk"
+            "注文と配送", Position(0, 0), "注文", "cjk"
+            "注文と配送", Position(0, 0), "配送", "cjk"
+            "オーダー", Position(0, 0), "注文", "cjk"
+            "购物车", Position(0, 0), "购物车", "cjk"
+            "사용자", Position(0, 0), "사용자", "cjk" ]
+          |> List.map testHoverTermFoundWithDefaultGlossary
+          |> testList "CJK term found when hovering via substring matching"
+
           let testHoverTermFoundWithMultipleGlossaries
               (fileName: string, text, position: Position, expectedTerm: string)
               =
@@ -178,7 +190,9 @@ let tests =
             "    anothernotterm", Position(0, 0), "one"
             "", Position(0, 0), "one"
             "peere", Position(0, 0), "three"
-            "Something", Position(0, 0), "empty_terms_list" ]
+            "Something", Position(0, 0), "empty_terms_list"
+            "料理", Position(0, 0), "cjk"
+            "ユーザー", Position(0, 0), "cjk" ]
           |> List.map testHoverTermNotFound
           |> testList "Nothing found when hovering"
 

--- a/src/language-server/Contextive.LanguageServer.Tests/fixtures/completion_tests/cjk.yml
+++ b/src/language-server/Contextive.LanguageServer.Tests/fixtures/completion_tests/cjk.yml
@@ -1,0 +1,14 @@
+contexts:
+  - terms:
+      - name: 注文
+        definition: An order placed by a customer
+        aliases:
+          - オーダー
+      - name: 購入
+        definition: A purchase transaction
+      - name: 配送
+        definition: Delivery of goods
+      - name: 사용자
+        definition: A user of the system
+      - name: 购物车
+        definition: Shopping cart

--- a/src/language-server/Contextive.LanguageServer/Hover.fs
+++ b/src/language-server/Contextive.LanguageServer/Hover.fs
@@ -63,6 +63,10 @@ module private Filtering =
             else
                 [])
 
+    // For CJK tokens, find terms whose index key is a substring of the token.
+    // Both token and keys are normalised with simpleNormalize (NFKD + lowercase +
+    // Singularize). Singularize is a no-op for CJK text in Humanizer, so the
+    // normalisation is effectively NFKD + lowercase on both sides.
     let findMatchingTermsBySubstring (context: GlossaryFile.Context) (token: string) =
         let normalizedToken = Normalization.simpleNormalize token
 
@@ -82,6 +86,8 @@ module private Filtering =
                 else
                     findMatchingTermsInIndex c tokenAndCandidateTerms
 
+            // For CJK substring matches, no term exactly equals the full token,
+            // so removeLessRelevantTerms falls through to returning all matched terms.
             GlossaryFile.Context.withTerms (terms |> removeLessRelevantTerms tokenAndCandidateTerms) c)
 
 module private TextDocument =

--- a/src/language-server/Contextive.LanguageServer/Hover.fs
+++ b/src/language-server/Contextive.LanguageServer/Hover.fs
@@ -63,10 +63,24 @@ module private Filtering =
             else
                 [])
 
+    let findMatchingTermsBySubstring (context: GlossaryFile.Context) (token: string) =
+        let normalizedToken = Normalization.simpleNormalize token
+
+        context.Index.Keys
+        |> Seq.filter (fun key -> normalizedToken.Contains(key))
+        |> Seq.collect (fun key -> context.Index[key])
+        |> Seq.distinctBy (fun t -> t.Name)
+
     let termFilterForCandidateTermsWithIndex tokenAndCandidateTerms =
         Seq.map (fun (c: GlossaryFile.Context) ->
 
-            let terms = findMatchingTermsInIndex c tokenAndCandidateTerms
+            let token = tokenAndCandidateTerms |> Seq.head |> fst
+
+            let terms =
+                if CandidateTerms.containsCJK token then
+                    findMatchingTermsBySubstring c token
+                else
+                    findMatchingTermsInIndex c tokenAndCandidateTerms
 
             GlossaryFile.Context.withTerms (terms |> removeLessRelevantTerms tokenAndCandidateTerms) c)
 


### PR DESCRIPTION
## Summary

Closes #118

- Add `containsCJK` function to detect CJK characters (Japanese, Chinese, Korean) in tokens
- Add substring matching for CJK tokens in hover lookup — glossary terms are matched as substrings within CJK text (e.g. hovering over `注文が届く` matches the term `注文`)
- CJK tokens bypass the existing camelCase/snake_case splitter since those patterns don't apply to CJK scripts

## How it works

1. **Detection**: `containsCJK` checks if a token contains characters in CJK Unified Ideographs, Kana, Hangul, or CJK Compatibility ranges
2. **Matching**: For CJK tokens, `findMatchingTermsBySubstring` normalises both the token and index keys (NFKD + lowercase), then checks if any key is a substring of the token
3. **Non-CJK tokens** continue to use the existing exact-match index lookup — no behaviour change

## Test plan

- [x] Unit tests for `containsCJK` (English, Kanji, Katakana, Hiragana, Chinese, Korean, mixed)
- [x] Unit tests for CJK term indexing in `GlossaryFileTests`
- [x] E2E hover tests: exact match, substring match, alias match, multi-term match, Chinese, Korean
- [x] E2E negative tests: terms not in glossary return no hover
- [x] All existing tests pass (no regressions)
